### PR TITLE
BE dev better route api's, bug fixes

### DIFF
--- a/tldr_be/resources/sql/queries.sql
+++ b/tldr_be/resources/sql/queries.sql
@@ -58,6 +58,12 @@ WHERE id = :id
 SELECT * FROM docs
 WHERE filename = :filename
 
+
+-- :name get-doc-by-id :? :1
+-- :doc retrieves a document given the file name
+SELECT * FROM docs
+WHERE id = :id
+
 -- :name get-doc-id :? :1
 -- :doc given a filename retrieve that docs doc_id
 SELECT id from docs

--- a/tldr_be/resources/sql/queries.sql
+++ b/tldr_be/resources/sql/queries.sql
@@ -48,19 +48,13 @@ INSERT INTO docs
 (filename, filestuff)
 VALUES (:filename, :filestuff)
 
--- :name get-doc :? :1
--- :doc retrieves a document record given the id
-SELECT * FROM docs
-WHERE id = :id
-
 -- :name get-doc-by-name :? :1
 -- :doc retrieves a document given the file name
 SELECT * FROM docs
 WHERE filename = :filename
 
-
 -- :name get-doc-by-id :? :1
--- :doc retrieves a document given the file name
+-- :doc retrieves a document given the
 SELECT * FROM docs
 WHERE id = :id
 

--- a/tldr_be/resources/sql/queries.sql
+++ b/tldr_be/resources/sql/queries.sql
@@ -48,7 +48,7 @@ INSERT INTO docs
 (filename, filestuff)
 VALUES (:filename, :filestuff)
 
--- :name get-doc-by-name :? :1
+-- :name get-doc-by-filename :? :1
 -- :doc retrieves a document given the file name
 SELECT * FROM docs
 WHERE filename = :filename

--- a/tldr_be/src/clj/tldr_be/doc/core.clj
+++ b/tldr_be/src/clj/tldr_be/doc/core.clj
@@ -32,14 +32,6 @@
       [false "Request Malformed"])))
 
 
-(defn get-doc-by-filename
-  "Given the params of a request, pull the filename out, if the filename is good
-  then query the db for the corresponding file by the filename"
-  [params]
-  (if-let [filename (:filename params)]
-    [true (get-doc-by-name {:filename filename})]
-    [false "file could not be found"]))
-
 (defn get-doc
   "Given the params of a request, try to pull out the filename, if that fails try
   to pull out the postgres id (pgid), with either pull out the file, if neither
@@ -52,6 +44,7 @@
       [true (cond fname (get-doc-by-name {:filename fname})
                   pgid (get-doc-by-id {:id (parse-int pgid)}))]
       [false ("file could not be found")])))
+
 
 (defn insert-xml-refs!
   "Given params from a request, pull the filename and a xml of file data, insert

--- a/tldr_be/src/clj/tldr_be/doc/core.clj
+++ b/tldr_be/src/clj/tldr_be/doc/core.clj
@@ -1,6 +1,7 @@
 (ns tldr-be.doc.core
   (:require [tldr-be.db.core :refer [create-doc!
                                      get-doc-by-name
+                                     get-doc-by-filename
                                      get-doc-by-id
                                      get-doc-id
                                      get-doc-filename

--- a/tldr_be/src/clj/tldr_be/doc/core.clj
+++ b/tldr_be/src/clj/tldr_be/doc/core.clj
@@ -43,6 +43,17 @@
     [true (get-doc-by-name {:filename filename})]
     [false "file could not be found"]))
 
+(defn get-doc
+  "Given the params of a request, try to pull out the filename, if that fails try
+  to pull out the postgres id (pgid), with either pull out the file, if neither
+  works return failure"
+  [params]
+  (let [fname (:filename params)
+        pgid (:pgid params)]
+    (if (or fname pgid)
+      [true (cond fname (get-doc-by-name {:filename fname})
+                  pgid (get-doc-by-id {:id pgid}))]
+      [false ("file could not be found")])))
 
 (defn insert-xml-refs!
   "Given params from a request, pull the filename and a xml of file data, insert

--- a/tldr_be/src/clj/tldr_be/doc/core.clj
+++ b/tldr_be/src/clj/tldr_be/doc/core.clj
@@ -1,6 +1,5 @@
 (ns tldr-be.doc.core
   (:require [tldr-be.db.core :refer [create-doc!
-                                     get-doc-by-name
                                      get-doc-by-filename
                                      get-doc-by-id
                                      get-doc-id
@@ -42,7 +41,7 @@
         pgid (:pgid params)]
     (println "HERHEHERE" pgid)
     (if (or fname pgid)
-      [true (cond fname (get-doc-by-name {:filename fname})
+      [true (cond fname (get-doc-by-filename {:filename fname})
                   pgid (get-doc-by-id {:id (parse-int pgid)}))]
       [false ("file could not be found")])))
 

--- a/tldr_be/src/clj/tldr_be/doc/core.clj
+++ b/tldr_be/src/clj/tldr_be/doc/core.clj
@@ -1,6 +1,7 @@
 (ns tldr-be.doc.core
   (:require [tldr-be.db.core :refer [create-doc!
                                      get-doc-by-name
+                                     get-doc-by-id
                                      get-doc-id
                                      get-doc-filename
                                      create-xml-refs!
@@ -10,15 +11,11 @@
                                      *neo4j_db*]]
             [clojure.string :refer [split]]
             [byte-streams :as bs]
-            [tldr-be.config :refer [env]]
             [clojure.xml :as xml]
+            [tldr-be.utils.core :refer [parse-int]]
             [tldr-be.doc.pdf-parse :as pdf]
             [tldr-be.doc.engines :as eng]
             [tldr-be.utils.core :refer [collect]]
-            [clojurewerkz.neocons.rest.nodes :as nn]
-            [clojurewerkz.neocons.rest.labels :as nl]
-            [clojurewerkz.neocons.rest.relationships :as nrl]
-            [clojurewerkz.neocons.rest.cypher :as cy]
             [clojure.java.io :as io]))
 
 (defn insert-doc!
@@ -50,9 +47,10 @@
   [params]
   (let [fname (:filename params)
         pgid (:pgid params)]
+    (println "HERHEHERE" pgid)
     (if (or fname pgid)
       [true (cond fname (get-doc-by-name {:filename fname})
-                  pgid (get-doc-by-id {:id pgid}))]
+                  pgid (get-doc-by-id {:id (parse-int pgid)}))]
       [false ("file could not be found")])))
 
 (defn insert-xml-refs!

--- a/tldr_be/src/clj/tldr_be/doc/core.clj
+++ b/tldr_be/src/clj/tldr_be/doc/core.clj
@@ -39,7 +39,6 @@
   [params]
   (let [fname (:filename params)
         pgid (:pgid params)]
-    (println "HERHEHERE" pgid)
     (if (or fname pgid)
       [true (cond fname (get-doc-by-filename {:filename fname})
                   pgid (get-doc-by-id {:id (parse-int pgid)}))]
@@ -106,13 +105,12 @@
 (defn get-fblob
   "pull out a file blob from the database given the name"
   [fname]
-  (-> (assoc {} :filename fname) get-doc-by-filename second))
+  (-> (assoc {} :filename fname) get-doc-by-filename))
 
 
 (defn fname-to-cljmap
  "make a clojure map given filename as string"
   [f fname]
-  ;; (-> fname get-fblob pdf-to-xml-headers xml-to-map))
   (-> fname get-fblob f xml-to-map))
 
 

--- a/tldr_be/src/clj/tldr_be/doc/handler.clj
+++ b/tldr_be/src/clj/tldr_be/doc/handler.clj
@@ -19,7 +19,7 @@
       (http/bad-request res))))
 
 
-(defn get-doc-by-filename
+(defn get-doc
   "Given a request that specifies a filename in the body, retrieve the first blob
   corresponding to that filename from the db"
   [req]

--- a/tldr_be/src/clj/tldr_be/doc/handler.clj
+++ b/tldr_be/src/clj/tldr_be/doc/handler.clj
@@ -23,7 +23,7 @@
   "Given a request that specifies a filename in the body, retrieve the first blob
   corresponding to that filename from the db"
   [req]
-  (let [[ok? res] (doc/get-doc-by-filename (:params req))]
+  (let [[ok? res] (doc/get-doc (:params req))]
     (if ok?
       {:status 200
        :headers {"Content-Type" "application/pdf"}

--- a/tldr_be/src/clj/tldr_be/neo4j/core.clj
+++ b/tldr_be/src/clj/tldr_be/neo4j/core.clj
@@ -53,14 +53,10 @@
 (defn _get-all-children
   "given n many nodes find all the children of each node in a set union"
   [& ts]
-  (let [[tpe nodes] (cond
-                      (every? string? ts) [:titles (map #(format "'%s'" %) ts)]
-                      (every? number? ts)  [:ids (map #(format "%d" %) ts)])
-        q0 (format "WITH [%s] as ts %n" (apply str (interpose "," nodes)))
+  (let [q0 (format "WITH [%s] as ts %n" (apply str (interpose "," ts)))
         q1 "MATCH (p:Original)-[:cites]->(c:Cited) \n"
-        q2 (condp = tpe
-               :titles "WHERE p.title in ts RETURN DISTINCT c \n"
-               :ids "WHERE ID(p) in ts RETURN DISTINCT c")]
+        q2 "WHERE p.title in ts OR ID(p) in ts RETURN DISTINCT c \n"]
+    (println (apply str q0 q1 q2))
     (map massage-node
          (-> (cy/query *neo4j_db* (apply str q0 q1 q2))
              (get-in [:data])

--- a/tldr_be/src/clj/tldr_be/neo4j/core.clj
+++ b/tldr_be/src/clj/tldr_be/neo4j/core.clj
@@ -31,23 +31,23 @@
   (conj (get-in node [:data]) (select-keys (:metadata node) [:id])))
 
 
-(defn find-node-by-title
-  "Given the title of a paper traverse the graph and retrieve that nodes data,
+(defn find-node
+  "Given the title or id of a paper traverse the graph and retrieve that nodes data,
   neo4j id, and postgres id"
-  [title]
+  [arg]
   (let [result (-> (cy/tquery
                     *neo4j_db*
-                    (format "MATCH (n:Original) WHERE n.title = \"%s\" RETURN n" title))
+                    ;; TODO fix this horrendously long line, also notice that we let neo4j deal with the type errors
+                    (format "MATCH (n:Original) where n.title = '%s' or ID(n) = %d RETURN n UNION MATCH (n:Cited) WHERE n.title = '%s' or ID(n) = %d RETURN n" arg arg arg arg))
                    first
                    (get "n"))
-        metadata (:metadata result)]
     (when result (massage-node result))))
 
 
 (defn node-exists?
-  "Given the title of a paper traverse the graph and check if node exist"
-  [title]
-  (not (nil? (find-node-by-title title))))
+  "Given the title or id of a paper traverse the graph and check if node exist"
+  [arg]
+  (not (nil? (find-node arg))))
 
 
 (defn _get-all-children

--- a/tldr_be/src/clj/tldr_be/neo4j/core.clj
+++ b/tldr_be/src/clj/tldr_be/neo4j/core.clj
@@ -61,6 +61,7 @@
         q2 (condp = tpe
                :titles "WHERE p.title in ts RETURN DISTINCT c \n"
                :ids "WHERE ID(p) in ts RETURN DISTINCT c")]
+    (println (map type ts))
     (map massage-node
          (-> (cy/query *neo4j_db* (apply str q0 q1 q2))
              (get-in [:data])

--- a/tldr_be/src/clj/tldr_be/neo4j/core.clj
+++ b/tldr_be/src/clj/tldr_be/neo4j/core.clj
@@ -61,7 +61,6 @@
         q2 (condp = tpe
                :titles "WHERE p.title in ts RETURN DISTINCT c \n"
                :ids "WHERE ID(p) in ts RETURN DISTINCT c")]
-    (println (map type ts))
     (map massage-node
          (-> (cy/query *neo4j_db* (apply str q0 q1 q2))
              (get-in [:data])
@@ -79,7 +78,33 @@
       [false "No papers found"])))
 
 
-;; TODO (defn get-all-shared-children)
+(defn _get-all-shared-children
+  [& ts]
+  (let [[tpe nodes] (cond
+                      (every? string? ts) [:titles (map #(format "'%s'" %) ts)]
+                      (every? number? ts)  [:ids (map #(format "%d" %) ts)])
+        q0 (format "WITH [%s] as ts %n" (apply str (interpose "," nodes)))
+        q1 "MATCH (p:Original)-[:cites]->(c:Cited) \n"
+        q2 (condp = tpe
+             :titles "WHERE p.title in ts\n"
+             :ids "WHERE ID(p) in ts\n")
+        q3 "WITH p. collect(c) as childrenPerParent \n WITH collect(childrenPerParent) as children\n"
+        q4 "WITH reduce(commonChildren == head(children). children in tail(children) | apoc.coll.intersection(commonChildren, children)) as commonChildren RETURN commonChildren"]
+    (map massage-node
+         (-> (cy/query *neo4j_db* (apply str q0 q1 q2 q3 q4))
+             (get-in [:data])
+             flatten))))
+
+
+(defn get-all-shared-children
+"Wrapper around the engine _get-all-children this function checks the results of
+  the service api, if good returns a 2-tuple (true, results) if bad return false
+  an error message"
+[& ts]
+(let [res (apply _get-all-shared-children ts)]
+  (if (not (empty? res))
+    [true res]
+    [false "No papers found"])))
 
 (defn insert-neo4j
   "Given a filename get the document id for the file out of postgres, then get the
@@ -106,5 +131,6 @@
         (nl/add *neo4j_db* parent "Original") ;; add Original label to parent
         ;; add Cited label to children
         (doall (map #(nl/add *neo4j_db* % "Cited") children))
+        ;; (add-child-and-edge parent (first children))
         ;; smart add the edges between parent and children
         (doall (map #(add-child-and-edge parent %) children))))))

--- a/tldr_be/src/clj/tldr_be/neo4j/core.clj
+++ b/tldr_be/src/clj/tldr_be/neo4j/core.clj
@@ -35,12 +35,10 @@
   "Given the title or id of a paper traverse the graph and retrieve that nodes data,
   neo4j id, and postgres id"
   [arg]
-  (let [result (-> (cy/tquery
-                    *neo4j_db*
-                    ;; TODO fix this horrendously long line, also notice that we let neo4j deal with the type errors
-                    (format "MATCH (n:Original) where n.title = '%s' or ID(n) = %d RETURN n UNION MATCH (n:Cited) WHERE n.title = '%s' or ID(n) = %d RETURN n" arg arg arg arg))
-                   first
-                   (get "n"))]
+  (let [q0 (cond
+             (string? arg) (format "MATCH (n:Original) where n.title = '%s' RETURN n UNION MATCH (n:Cited) WHERE n.title = '%s' RETURN n" arg arg)
+             (number? arg) (format "MATCH (n:Original) where ID(n) = %d RETURN n UNION MATCH (n:Cited) WHERE ID(n) = %d RETURN n" arg arg))
+        result (-> (cy/tquery *neo4j_db* q0) first (get "n"))]
     (when result (massage-node result))))
 
 

--- a/tldr_be/src/clj/tldr_be/neo4j/handler.clj
+++ b/tldr_be/src/clj/tldr_be/neo4j/handler.clj
@@ -1,6 +1,7 @@
 (ns tldr-be.neo4j.handler
   (:require [tldr-be.neo4j.core :as neo]
             [ring.util.http-response :as http]
+            [tldr-be.utils.core :refer [parse-int]]
             [clojure.string :as str]))
 
 
@@ -8,8 +9,12 @@
   "Given a request that specifies a n-many paper titles get all children for each
   paper with no duplicates"
   [req]
-  (let [titles (get-in req [:query-params "titles"])
-        [ok? res] (apply neo/get-all-children (map #(str/replace % "\"" "") titles))]
+  (let [ts (not-empty (select-keys (:query-params req) ["titles"]))
+        is (not-empty (select-keys (:query-params req) ["ids"]))
+        args (if ts
+               (map #(str/replace % "\"" "") (get ts "titles"))
+               (map parse-int (get is "ids")))
+        [ok? res] (apply neo/get-all-children args)]
     (if ok?
       {:status 200
        :headers {"Content-Type" "application/json"}

--- a/tldr_be/src/clj/tldr_be/neo4j/handler.clj
+++ b/tldr_be/src/clj/tldr_be/neo4j/handler.clj
@@ -11,9 +11,10 @@
   [req]
   (let [ts (not-empty (select-keys (:query-params req) ["titles"]))
         is (not-empty (select-keys (:query-params req) ["ids"]))
-        args (if ts
-               (map #(str/replace % "\"" "") (get ts "titles"))
-               (map parse-int (get is "ids")))
+        args (distinct (concat
+                        (map #(format "'%s'" (str/replace % "\"" ""))
+                             (get ts "titles"))
+                        (map parse-int (get is "ids"))))
         [ok? res] (apply neo/get-all-children args)]
     (if ok?
       {:status 200

--- a/tldr_be/src/clj/tldr_be/routes/home.clj
+++ b/tldr_be/src/clj/tldr_be/routes/home.clj
@@ -27,9 +27,9 @@
   (GET "/about" [] (about-page)))
 
 (defroutes bus-routes ;;business-routes
-  (POST "/api/uploadFile/"    [] d/insert-doc!)
-  (POST "/api/getFileByName/" [] d/get-doc-by-filename)
-  (GET "/api/getChildrenUnion/" [] neo/get-all-children)
+  (POST "/api/uploadFile/"       [] d/insert-doc!)
+  (POST "/api/getFile/"          [] d/get-doc)
+  (GET  "/api/getChildrenUnion/" [] neo/get-all-children)
   ;; (POST "/api/addSummary/"    [] sum_handler/insert-sum)
   ;; (POST "/api/sumUpVote/"     [] sum_handler/up-vote-sum)
   ;; (POST "/api/sumDownVote/"   [] sum_handler/down-vote-sum)

--- a/tldr_be/src/clj/tldr_be/utils/core.clj
+++ b/tldr_be/src/clj/tldr_be/utils/core.clj
@@ -23,3 +23,7 @@
   "function accepts a string and returns one with specified characters removed."
   [str]
   (str/replace str "\"" "'"))
+
+(defn parse-int [s]
+  "given a messy string grab the numbers out of it and convert to integers"
+  (Integer. (re-find  #"\d+" s )))

--- a/tldr_be/src/clj/tldr_be/utils/core.clj
+++ b/tldr_be/src/clj/tldr_be/utils/core.clj
@@ -27,3 +27,5 @@
 (defn parse-int [s]
   "given a messy string grab the numbers out of it and convert to integers"
   (Integer. (re-find  #"\d+" s )))
+
+(def not-nil? (complement nil?))


### PR DESCRIPTION
### What this PR adds
Before this PR you needed to send homogenous lists of information to the `getAllChildrenUnion` route like this: `http://localhost:3000/api/getChildrenUnion/?title="Variational Databases"&title="Formula Choice Calculus"` with this PR you can now do this: `http://localhost:3000/api/getChildrenUnion/?title="Variational Databases"&ids=1140&title="Formula Choice Calculus"` notice that there is an `ids` now. Furthermore you can pass n-many.

### How do I know this doesn't break anything
You don't, we need to do testing on the backend